### PR TITLE
Separate Counter & Timer IDs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@
 /build
 /build-*
 /.cache
+/out
+/.vs
+/.vscode

--- a/api/NIDEnum.hpp
+++ b/api/NIDEnum.hpp
@@ -15,5 +15,11 @@ enum class NID
 
 struct dynamic_prop_toggle_t {
 	uint16_t togglePropID;
-	bool counterState; // timer otherwise
+	uint8_t counterState; // timer otherwise
+};
+
+struct dynamic_prop_choice_t {
+	uint16_t targetPropID;
+	uint8_t counterState;
+	uint8_t timerState;
 };

--- a/api/NIDEnum.hpp
+++ b/api/NIDEnum.hpp
@@ -5,8 +5,15 @@ enum class NID
 	GROUP,
 	COLLISION,
 	COUNTER,
+	TIMER,
+	DYNAMIC_COUNTER_TIMER,
 
 #ifdef SPAGHETTDEV_NAMED_EDITOR_GROUPS_EXPORTING
 	_INTERNAL_LAST
 #endif
+};
+
+struct dynamic_prop_toggle_t {
+	uint16_t togglePropID;
+	bool counterState; // timer otherwise
 };

--- a/src/data/NIDManager.cpp
+++ b/src/data/NIDManager.cpp
@@ -148,7 +148,12 @@ void NIDManager::importNamedIDs(const std::string& str)
 	auto groupsStr = strView.substr(0, firstDelimPos);
 	auto blocksStr = strView.substr(firstDelimPos + 1, secondDelimPos - firstDelimPos - 1);
 	auto itemsStr = strView.substr(secondDelimPos + 1, thirdDelimPos - secondDelimPos - 1);
-	auto timersStr = strView.substr(thirdDelimPos + 1);
+
+	std::string timersStr;
+	if (thirdDelimPos >= strView.length())
+		timersStr = "";
+	else
+		strView.substr(thirdDelimPos + 1);
 
 	g_namedGroups = g_namedGroups.from(std::move(groupsStr));
 	g_namedCollisions = g_namedCollisions.from(std::move(blocksStr));

--- a/src/data/NIDManager.cpp
+++ b/src/data/NIDManager.cpp
@@ -148,7 +148,7 @@ void NIDManager::importNamedIDs(const std::string& str)
 	auto groupsStr = strView.substr(0, firstDelimPos);
 	auto blocksStr = strView.substr(firstDelimPos + 1, secondDelimPos - firstDelimPos - 1);
 	auto itemsStr = strView.substr(secondDelimPos + 1, thirdDelimPos - secondDelimPos - 1);
-	auto timersStr = strView.substr(thirdDelimPos);
+	auto timersStr = strView.substr(thirdDelimPos + 1);
 
 	g_namedGroups = g_namedGroups.from(std::move(groupsStr));
 	g_namedCollisions = g_namedCollisions.from(std::move(blocksStr));

--- a/src/hooks/objects/ObjectLabels.cpp
+++ b/src/hooks/objects/ObjectLabels.cpp
@@ -27,8 +27,9 @@ struct NIDEffectGameObject : geode::Modify<NIDEffectGameObject, EffectGameObject
 		bool isTrigger = objInArray(this, ng::constants::TRIGGER_OBJECT_IDS_WITH_LABEL);
 		bool isCollision = objInArray(this, ng::constants::COLLISION_OBJECT_IDS_WITH_LABEL);
 		bool isCounter = objInArray(this, ng::constants::COUNTER_OBJECT_IDS_WITH_LABEL);
+		bool isTimer = objInArray(this, ng::constants::TIMER_OBJECT_IDS_WITH_LABEL);
 
-		if (!(isTrigger || isCollision || isCounter))
+		if (!(isTrigger || isCollision || isCounter || isTimer))
 			return;
 
 		auto idNameLabel = CCLabelBMFont::create("", "bigFont.fnt");

--- a/src/hooks/objects/ObjectLabels.cpp
+++ b/src/hooks/objects/ObjectLabels.cpp
@@ -49,8 +49,9 @@ struct NIDLevelEditorLayer : geode::Modify<NIDLevelEditorLayer, LevelEditorLayer
 		bool isTrigger = objInArray(object, ng::constants::TRIGGER_OBJECT_IDS_WITH_LABEL);
 		bool isCollision = objInArray(object, ng::constants::COLLISION_OBJECT_IDS_WITH_LABEL);
 		bool isCounter = objInArray(object, ng::constants::COUNTER_OBJECT_IDS_WITH_LABEL);
+		bool isTimer = objInArray(object, ng::constants::TIMER_OBJECT_IDS_WITH_LABEL);
 
-		if (!(isTrigger || isCollision || isCounter))
+		if (!(isTrigger || isCollision || isCounter || isTimer))
 			return;
 
 		auto effectGameObj = static_cast<NIDEffectGameObject*>(object);
@@ -69,6 +70,7 @@ struct NIDLevelEditorLayer : geode::Modify<NIDLevelEditorLayer, LevelEditorLayer
 			case 1615u:
 				idLabelPos = CCPoint{ 21.75f, 7.75f };
 
+				// LabelGameObject::m_label
 				if (auto label = effectGameObj->getChildByID("counter-label"); !label)
 				{
 					if (auto idLabel = effectGameObj->getChildByType<CCLabelBMFont*>(0))
@@ -94,7 +96,22 @@ struct NIDLevelEditorLayer : geode::Modify<NIDLevelEditorLayer, LevelEditorLayer
 
 		std::string idNameStr = "";
 
-		if (isTrigger)
+		// hardcode counter object (only dynamic label)
+		if (object->m_objectID == 1615u)
+		{
+			auto labelNode = static_cast<LabelGameObject*>(object);
+			if (labelNode->m_shownSpecial != 0) // Disable if counter should show MainTime/Points/Attempts
+				idNameStr = "";
+			else if (labelNode->m_isTimeCounter)
+				idNameStr = NIDManager::getNameForID<NID::TIMER>(
+					effectGameObj->m_itemID
+				).unwrapOr("");
+			else
+				idNameStr = NIDManager::getNameForID<NID::COUNTER>(
+					effectGameObj->m_itemID
+				).unwrapOr("");
+		}
+		else if (isTrigger)
 		{
 			// random trigger
 			if (effectGameObj->m_objectID == 1912u)
@@ -123,6 +140,10 @@ struct NIDLevelEditorLayer : geode::Modify<NIDLevelEditorLayer, LevelEditorLayer
 			).unwrapOr("");
 		else if (isCounter)
 			idNameStr = NIDManager::getNameForID<NID::COUNTER>(
+				effectGameObj->m_itemID
+			).unwrapOr("");
+		else if (isTimer) // Counter object (only timer label) will be caught by hardcode, but for futureproofing
+			idNameStr = NIDManager::getNameForID<NID::TIMER>(
 				effectGameObj->m_itemID
 			).unwrapOr("");
 

--- a/src/hooks/ui/SetupPopups.cpp
+++ b/src/hooks/ui/SetupPopups.cpp
@@ -133,7 +133,8 @@ NIDSetupTriggerPopup::IDInputInfo NIDSetupTriggerPopup::commonSetup(NID nid, std
 	CCPoint inputNodePos;
 	float scale = 1.f;
 
-	inputInfo.idType = evaluateDynamicType(nid, property);
+	inputInfo.idType = nid;
+	NID currentNid = evaluateDynamicType(nid, property);
 
 	for (auto node : nodes)
 		if (auto bg = typeinfo_cast<cocos2d::extension::CCScale9Sprite*>(node))
@@ -214,7 +215,7 @@ NIDSetupTriggerPopup::IDInputInfo NIDSetupTriggerPopup::commonSetup(NID nid, std
 
 	auto inputIDNum = numFromString<short>(inputInfo.idInput->getString()).unwrapOr(0);
 
-	if (auto name = NIDManager::getNameForID(inputInfo.idType, inputIDNum); name.isOk())
+	if (auto name = NIDManager::getNameForID(currentNid, inputIDNum); name.isOk())
 		groupNameInput->setString(name.unwrap());
 
 	if (finishedCallback)

--- a/src/hooks/ui/SetupPopups.cpp
+++ b/src/hooks/ui/SetupPopups.cpp
@@ -87,7 +87,7 @@ void NIDSetupTriggerPopup::triggerArrowWasClicked(int senderTag, bool isRight)
 
 	idInputInfo.namedIDInput->getInputNode()->onClickTrackNode(false);
 	idInputInfo.namedIDInput->setString(
-		NIDManager::getNameForID(idInputInfo.idType, idInputValue).unwrapOr("")
+		NIDManager::getNameForID(evaluateDynamicType(idInputInfo.idType, senderTag), idInputValue).unwrapOr("")
 	);
 }
 
@@ -99,7 +99,7 @@ void NIDSetupTriggerPopup::textWasChanged(CCTextInputNode* input)
 
 	if (auto parsedNum = numFromString<short>(idInputInfo.idInput->getString()); parsedNum.isOk())
 		idInputInfo.namedIDInput->setString(
-			NIDManager::getNameForID(idInputInfo.idType, parsedNum.unwrap()).unwrapOr("")
+			NIDManager::getNameForID(evaluateDynamicType(idInputInfo.idType, input->getTag()), parsedNum.unwrap()).unwrapOr("")
 		);
 }
 
@@ -108,7 +108,7 @@ void NIDSetupTriggerPopup::onEditIDNameButton(CCObject* sender)
 	auto& idInputInfo = m_fields->m_id_inputs.at(sender->getTag());
 
 	ShowEditNamedIDPopup(
-		evaluateDynamicType(idInputInfo, sender->getTag()),
+		evaluateDynamicType(idInputInfo.idType, sender->getTag()),
 		geode::utils::numFromString<short>(idInputInfo.idInput->getString()).unwrapOr(0),
 		[&](short id) {
 			idInputInfo.idInput->setString(fmt::format("{}", id));
@@ -123,7 +123,7 @@ void NIDSetupTriggerPopup::onEditInput(NIDSetupTriggerPopup* self, std::uint16_t
 {
 	auto& idInputInfo = self->m_fields->m_id_inputs.at(property);
 
-	if (auto name = NIDManager::getIDForName(idInputInfo.idType, str); name.isOk())
+	if (auto name = NIDManager::getIDForName(self->evaluateDynamicType(idInputInfo.idType, property), str); name.isOk())
 		idInputInfo.idInput->setString(fmt::format("{}", name.unwrap()));
 }
 
@@ -133,7 +133,7 @@ NIDSetupTriggerPopup::IDInputInfo NIDSetupTriggerPopup::commonSetup(NID nid, std
 	CCPoint inputNodePos;
 	float scale = 1.f;
 
-	inputInfo.idType = nid;
+	inputInfo.idType = evaluateDynamicType(nid, property);
 
 	for (auto node : nodes)
 		if (auto bg = typeinfo_cast<cocos2d::extension::CCScale9Sprite*>(node))
@@ -242,18 +242,71 @@ void NIDSetupTriggerPopup::handleSpecialCases(int gameObjectID, std::uint16_t pr
 	}
 }
 
-NID NIDSetupTriggerPopup::evaluateDynamicType(IDInputInfo idInputInfo, short tag) {
-	if (idInputInfo.idType != NID::DYNAMIC_COUNTER_TIMER) return idInputInfo.idType;
+NID NIDSetupTriggerPopup::evaluateDynamicType(NID nid, short tag) {
+	if (nid != NID::DYNAMIC_COUNTER_TIMER) return nid;
 
-	short toggleTag = 0;
 	auto& toggleMap = ng::constants::DNAMIC_PROPERTIES_TOGGLES.at(this->m_gameObject->m_objectID);
 	auto& toggleInfo = toggleMap.at(tag);
+	auto propVal = this->getTriggerValue(toggleInfo.togglePropID, this->m_gameObject);
 
-	auto toggleNode = this->m_buttonMenu->getChildByTag(toggleInfo.togglePropID);
-	if (!toggleNode) return NID::COUNTER; // Fallback
-
-	auto toggleInput = static_cast<CCMenuItemToggler*>(toggleNode);
-	bool toggleState = toggleInput->isToggled();
-
-	return toggleState == toggleInfo.counterState ? NID::COUNTER : NID::TIMER;
+	return propVal == toggleInfo.counterState ? NID::COUNTER : NID::TIMER;
 }
+
+// Persistent Item & Counter (Binary Toggles)
+void NIDSetupTriggerPopup::valueChanged(int property, float value) {
+	SetupTriggerPopup::valueChanged(property, value);
+
+	if (!ng::constants::DNAMIC_PROPERTIES_TOGGLES.contains(this->m_gameObject->m_objectID)) return;
+	for (auto const& [key, val] : ng::constants::DNAMIC_PROPERTIES_TOGGLES.at(this->m_gameObject->m_objectID)) {
+		if (val.togglePropID != property) continue;
+
+		NID type = val.counterState == value ? NID::COUNTER : NID::TIMER;
+
+		auto inputNode = typeinfo_cast<CCTextInputNode*>(this->m_mainLayer->getChildByTag(key));
+
+		if (!m_fields->m_id_inputs.contains(key)) return;
+
+		auto parsedIdInputValue = geode::utils::numFromString<short>(inputNode->getString());
+		if (parsedIdInputValue.isErr()) return;
+		short idInputValue = parsedIdInputValue.unwrap();
+
+		auto& idInputInfo = m_fields->m_id_inputs.at(key);
+
+		idInputInfo.namedIDInput->getInputNode()->onClickTrackNode(false);
+		idInputInfo.namedIDInput->setString(
+			NIDManager::getNameForID(type, idInputValue).unwrapOr("")
+		);
+		break;
+	}
+};
+
+// Item Edit & Item Comp (Multiple Choice Toggles)
+void NIDSetupTriggerPopup::updateValue(int property, float value) {
+	SetupTriggerPopup::updateValue(property, value);
+
+	if (!ng::constants::DNAMIC_PROPERTIES_CHOICES.contains(this->m_gameObject->m_objectID)) return;
+	auto& choiceProperties = ng::constants::DNAMIC_PROPERTIES_CHOICES.at(this->m_gameObject->m_objectID);
+
+	if (!choiceProperties.contains(property)) return;
+	auto& choiceInfo = choiceProperties.at(property);
+
+	auto targetTag = choiceInfo.targetPropID;
+	NID type = choiceInfo.timerState == value ? NID::TIMER :
+		choiceInfo.counterState == value ? NID::COUNTER : NID::DYNAMIC_COUNTER_TIMER;
+
+	auto inputNode = typeinfo_cast<CCTextInputNode*>(this->m_mainLayer->getChildByTag(targetTag));
+
+	if (!m_fields->m_id_inputs.contains(targetTag)) return;
+
+	auto parsedIdInputValue = geode::utils::numFromString<short>(inputNode->getString());
+	if (parsedIdInputValue.isErr()) return;
+	short idInputValue = parsedIdInputValue.unwrap();
+
+	auto& idInputInfo = m_fields->m_id_inputs.at(targetTag);
+
+	idInputInfo.namedIDInput->getInputNode()->onClickTrackNode(false);
+	idInputInfo.namedIDInput->setString(
+		type == NID::DYNAMIC_COUNTER_TIMER ? "" :
+		NIDManager::getNameForID(type, idInputValue).unwrapOr("")
+	);
+};

--- a/src/hooks/ui/SetupPopups.cpp
+++ b/src/hooks/ui/SetupPopups.cpp
@@ -108,7 +108,7 @@ void NIDSetupTriggerPopup::onEditIDNameButton(CCObject* sender)
 	auto& idInputInfo = m_fields->m_id_inputs.at(sender->getTag());
 
 	ShowEditNamedIDPopup(
-		idInputInfo.idType,
+		evaluateDynamicType(idInputInfo, sender->getTag()),
 		geode::utils::numFromString<short>(idInputInfo.idInput->getString()).unwrapOr(0),
 		[&](short id) {
 			idInputInfo.idInput->setString(fmt::format("{}", id));
@@ -240,4 +240,20 @@ void NIDSetupTriggerPopup::handleSpecialCases(int gameObjectID, std::uint16_t pr
 		default:
 			break;
 	}
+}
+
+NID NIDSetupTriggerPopup::evaluateDynamicType(IDInputInfo idInputInfo, short tag) {
+	if (idInputInfo.idType != NID::DYNAMIC_COUNTER_TIMER) return idInputInfo.idType;
+
+	short toggleTag = 0;
+	auto& toggleMap = ng::constants::DNAMIC_PROPERTIES_TOGGLES.at(this->m_gameObject->m_objectID);
+	auto& toggleInfo = toggleMap.at(tag);
+
+	auto toggleNode = this->m_buttonMenu->getChildByTag(toggleInfo.togglePropID);
+	if (!toggleNode) return NID::COUNTER; // Fallback
+
+	auto toggleInput = static_cast<CCMenuItemToggler*>(toggleNode);
+	bool toggleState = toggleInput->isToggled();
+
+	return toggleState == toggleInfo.counterState ? NID::COUNTER : NID::TIMER;
 }

--- a/src/hooks/ui/SetupPopups.hpp
+++ b/src/hooks/ui/SetupPopups.hpp
@@ -32,6 +32,7 @@ struct NIDSetupTriggerPopup : geode::Modify<NIDSetupTriggerPopup, SetupTriggerPo
 	void triggerArrowRight(cocos2d::CCObject*);
 	virtual void textChanged(CCTextInputNode*) override;
 
+	NID evaluateDynamicType(IDInputInfo, short);
 
 	void triggerArrowWasClicked(int, bool);
 	void textWasChanged(CCTextInputNode*);

--- a/src/hooks/ui/SetupPopups.hpp
+++ b/src/hooks/ui/SetupPopups.hpp
@@ -32,7 +32,10 @@ struct NIDSetupTriggerPopup : geode::Modify<NIDSetupTriggerPopup, SetupTriggerPo
 	void triggerArrowRight(cocos2d::CCObject*);
 	virtual void textChanged(CCTextInputNode*) override;
 
-	NID evaluateDynamicType(IDInputInfo, short);
+	void valueChanged(int property, float value);
+	void updateValue(int property, float value);
+
+	NID evaluateDynamicType(NID, short);
 
 	void triggerArrowWasClicked(int, bool);
 	void textWasChanged(CCTextInputNode*);

--- a/src/popups/EditNamedIDPopup.cpp
+++ b/src/popups/EditNamedIDPopup.cpp
@@ -240,3 +240,4 @@ void EditNamedIDPopup<nid>::onEditIDNameInput(EditNamedIDPopup<nid>* self, const
 template class EditNamedIDPopup<NID::GROUP>;
 template class EditNamedIDPopup<NID::COLLISION>;
 template class EditNamedIDPopup<NID::COUNTER>;
+template class EditNamedIDPopup<NID::TIMER>;

--- a/src/popups/EditNamedIDPopup.hpp
+++ b/src/popups/EditNamedIDPopup.hpp
@@ -38,12 +38,20 @@ protected:
 	std::function<void()> m_saved_callback;
 };
 
-static inline void ShowEditNamedIDPopup(NID nid, short id, std::function<void(short)>&& changedIDCallback, std::function<void()>&& savedCallback)
+static inline void ShowEditNamedIDPopup(const NID nid, short id, std::function<void(short)>&& changedIDCallback, std::function<void()>&& savedCallback)
 {
-	if (nid == NID::GROUP)
-		EditNamedIDPopup<NID::GROUP>::create(id, std::move(changedIDCallback), std::move(savedCallback))->show();
-	else if (nid == NID::COLLISION)
-		EditNamedIDPopup<NID::COLLISION>::create(id, std::move(changedIDCallback), std::move(savedCallback))->show();
-	else if (nid == NID::COUNTER)
-		EditNamedIDPopup<NID::COUNTER>::create(id, std::move(changedIDCallback), std::move(savedCallback))->show();
+	switch (nid) {
+		case NID::GROUP:
+			EditNamedIDPopup<NID::GROUP>::create(id, std::move(changedIDCallback), std::move(savedCallback))->show();
+			break;
+		case NID::COLLISION:
+			EditNamedIDPopup<NID::COLLISION>::create(id, std::move(changedIDCallback), std::move(savedCallback))->show();
+			break;
+		case NID::COUNTER:
+			EditNamedIDPopup<NID::COUNTER>::create(id, std::move(changedIDCallback), std::move(savedCallback))->show();
+			break;
+		case NID::TIMER:
+			EditNamedIDPopup<NID::TIMER>::create(id, std::move(changedIDCallback), std::move(savedCallback))->show();
+			break;
+	}
 }

--- a/src/popups/SelectIDFilterPopup.cpp
+++ b/src/popups/SelectIDFilterPopup.cpp
@@ -36,7 +36,7 @@ bool SelectIDFilterPopup::setup(NID currNid, std::function<void(NID)>&& onChange
 	m_toggles_menu->setPosition({ 75.5f, 58.f });
 	this->m_buttonMenu->addChild(m_toggles_menu);
 
-	for (NID nid = NID::GROUP; nid < NID::_INTERNAL_LAST; nid = static_cast<NID>(static_cast<int>(nid) + 1))
+	for (NID nid = NID::GROUP; nid < NID::DYNAMIC_COUNTER_TIMER; nid = static_cast<NID>(static_cast<int>(nid) + 1))
 	{
 		auto toggleMenu = CCMenu::create();
 		toggleMenu->setContentSize({ 150.f, 50.f });

--- a/src/utils/constants.hpp
+++ b/src/utils/constants.hpp
@@ -437,31 +437,52 @@ namespace ng
 			// Item Edit Trigger
 			{ 3619, {
 				// Item ID 1
-				{ 80, { 2, false } },
+				{ 80, { 476, 1 } },
 				// Item ID 2
-				{ 95, { 102, false } },
+				{ 95, { 477, 1 } },
 				// Target Item ID
-				{ 51, { 1002, false } },
+				{ 51, { 478, 1 } },
 			} },
 
 			// Item Compare Trigger
 			{ 3620, {
 				// Item ID 1
-				{ 80, { 2, false } },
+				{ 80, { 476, 1 } },
 				// Item ID 2
-				{ 95, { 102, false } },
+				{ 95, { 477, 1 } },
 			} },
 
 			// Persistent Item Trigger
 			{ 3641, {
 				// Item ID
-				{ 80, { 494, false } },
+				{ 80, { 494, 0 } },
 			} },
 
 			// Counter Label
 			{ 1615, {
 				// Item ID
-				{ 80, { 466, false } },
+				{ 80, { 466, 0 } },
+			} },
+		};
+
+		const std::unordered_map<std::uint16_t, const std::unordered_map<std::uint16_t, struct dynamic_prop_choice_t>> DNAMIC_PROPERTIES_CHOICES{
+
+			// Item Edit Trigger
+			{ 3619, {
+				// Item ID 1
+				{ 476, { 80, 1, 2 } },
+				// Item ID 2
+				{ 477, { 95, 1, 2 } },
+				// Target Item ID
+				{ 478, { 51, 1, 2 } },
+			} },
+
+			// Item Compare Trigger
+			{ 3620, {
+				// Item ID 1
+				{ 476, { 80, 1, 2 } },
+				// Item ID 2
+				{ 477, { 95, 1, 2 } },
 			} },
 		};
 	}

--- a/src/utils/constants.hpp
+++ b/src/utils/constants.hpp
@@ -34,6 +34,10 @@ namespace ng
 			1811u, 1817u, 1615u
 		};
 
+		constexpr std::array TIMER_OBJECT_IDS_WITH_LABEL{
+			1615u
+		};
+
 		const std::unordered_map<std::uint16_t, const std::unordered_map<std::uint16_t, NID>> OBJECT_ID_TO_PROPERTIES_INFO{
 			// Move Trigger
 			{ 901, {
@@ -282,37 +286,42 @@ namespace ng
 			// Timer Trigger
 			{ 3614, {
 				// Item ID
-				{ 80, NID::COUNTER },
+				{ 80, NID::TIMER },
 				// Target ID
 				{ 51, NID::GROUP }
 			} },
 			// Timer Event Trigger
 			{ 3615, {
 				// Item ID
-				{ 80, NID::COUNTER },
+				{ 80, NID::TIMER },
 				// Target ID
 				{ 51, NID::GROUP }
 			} },
 			// Timer Control Trigger
 			{ 3617, {
 				// Item ID
-				{ 80, NID::COUNTER }
+				{ 80, NID::TIMER }
 			} },
 			// Item Edit Trigger
 			{ 3619, {
 				// Item ID 1
-				{ 80, NID::COUNTER },
+				{ 80, NID::DYNAMIC_COUNTER_TIMER },
+				// 476 = 1 if item, 2 if timer
 				// Item ID 2
-				{ 95, NID::COUNTER },
+				{ 95, NID::DYNAMIC_COUNTER_TIMER },
+				// 477 = 1 if item, 2 if timer
 				// Target Item ID
-				{ 51, NID::COUNTER }
+				{ 51, NID::DYNAMIC_COUNTER_TIMER }
+				// 478 = 1 if item, 2 if timer
 			} },
 			// Item Compare Trigger
 			{ 3620, {
 				// Item ID 1
-				{ 80, NID::COUNTER },
+				{ 80, NID::DYNAMIC_COUNTER_TIMER },
+				// 476 = 1 if item, 2 if timer
 				// Item ID 2
-				{ 95, NID::COUNTER },
+				{ 95, NID::DYNAMIC_COUNTER_TIMER },
+				// 477 = 1 if item, 2 if timer
 				// True ID
 				{ 51, NID::GROUP },
 				// False ID
@@ -320,7 +329,8 @@ namespace ng
 			} },
 			// Persistent Item Trigger
 			{ 3641, {
-				{ 80, NID::COUNTER }
+				{ 80, NID::DYNAMIC_COUNTER_TIMER }
+				// 494: 1 if counter
 			} },
 			// Visibility Link Trigger
 			{ 3662, {
@@ -330,7 +340,8 @@ namespace ng
 
 			// Counter Label
 			{ 1615, {
-				{ 80, NID::COUNTER }
+				{ 80, NID::DYNAMIC_COUNTER_TIMER }
+				// 466: 1 if counter, unspecified if timer
 			} },
 			// Checkpoint Object
 			{ 2063, {
@@ -419,6 +430,39 @@ namespace ng
 				// Item ID
 				{ 80, NID::COUNTER }
 			} }
+		};
+
+		const std::unordered_map<std::uint16_t, const std::unordered_map<std::uint16_t, struct dynamic_prop_toggle_t>> DNAMIC_PROPERTIES_TOGGLES{
+
+			// Item Edit Trigger
+			{ 3619, {
+				// Item ID 1
+				{ 80, { 2, false } },
+				// Item ID 2
+				{ 95, { 102, false } },
+				// Target Item ID
+				{ 51, { 1002, false } },
+			} },
+
+			// Item Compare Trigger
+			{ 3620, {
+				// Item ID 1
+				{ 80, { 2, false } },
+				// Item ID 2
+				{ 95, { 102, false } },
+			} },
+
+			// Persistent Item Trigger
+			{ 3641, {
+				// Item ID
+				{ 80, { 494, false } },
+			} },
+
+			// Counter Label
+			{ 1615, {
+				// Item ID
+				{ 80, { 466, false } },
+			} },
 		};
 	}
 }

--- a/src/utils/utils.hpp
+++ b/src/utils/utils.hpp
@@ -21,6 +21,8 @@ namespace ng
 				return "Collision ID";
 			else if constexpr (nid == NID::COUNTER)
 				return "Counter ID";
+			else if constexpr (nid == NID::TIMER)
+				return "Timer ID";
 
 			throw "Invalid Named ID enum value";
 		}
@@ -33,6 +35,8 @@ namespace ng
 				return getNamedIDIndentifier<NID::COLLISION>();
 			else if (nid == NID::COUNTER)
 				return getNamedIDIndentifier<NID::COUNTER>();
+			else if (nid == NID::TIMER)
+				return getNamedIDIndentifier<NID::TIMER>();
 
 			throw "Invalid Named ID enum value";
 		}

--- a/src/utils/utils.hpp
+++ b/src/utils/utils.hpp
@@ -23,6 +23,8 @@ namespace ng
 				return "Counter ID";
 			else if constexpr (nid == NID::TIMER)
 				return "Timer ID";
+			else if constexpr (nid == NID::DYNAMIC_COUNTER_TIMER)
+				return "THIS SHOULD NOT HAPPEN REPORT ASAP";
 
 			throw "Invalid Named ID enum value";
 		}
@@ -37,6 +39,8 @@ namespace ng
 				return getNamedIDIndentifier<NID::COUNTER>();
 			else if (nid == NID::TIMER)
 				return getNamedIDIndentifier<NID::TIMER>();
+			else if (nid == NID::DYNAMIC_COUNTER_TIMER)
+				return getNamedIDIndentifier<NID::DYNAMIC_COUNTER_TIMER>();
 
 			throw "Invalid Named ID enum value";
 		}


### PR DESCRIPTION
Love the mod. But one thing bothered me, so I fixed it. Counter and Timer IDs are completely separated.

These changes make the mod behave differently for timer ID fields and now supports dynamic ID fields (such as in Edit Item, where another settings determines if a given input is treated as a counter or timer). The label on counter objects also automatically adjusts.

![counter-timer-ids-split-demo](https://github.com/user-attachments/assets/6e9257f9-0e80-42d9-a676-862eb479d2dd)

If you want to add me to developers or credit somewhere, use the name "FreakyRobot" pls thank you :>